### PR TITLE
Make replyOnce take precedents

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -210,7 +210,7 @@ function addHandler(method, handlers, handler) {
     if (indexOfExistingHandler > -1 && handler.length < 7) {
       handlers[method].splice(indexOfExistingHandler, 1, handler);
     } else {
-      handlers[method].push(handler);
+      handlers[method].unshift(handler);
     }
   }
 }


### PR DESCRIPTION
Previously `replyOnce` handlers were pushed to the end. This resulted in previously applied handlers taking precedents